### PR TITLE
(st-switch): Label color is different to the form input one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.14.0 (upcoming)
 
 * Removed st-button and define new button classes
+* St-switch: Label color is different to the form input one
 
 ## 0.13.0 (July 12, 2017)
 

--- a/src/components/_form-label.scss
+++ b/src/components/_form-label.scss
@@ -1,6 +1,10 @@
 @import '../../node_modules/@stratio/egeo-ui-base/utils/typography';
 @import '../../node_modules/@stratio/egeo-ui-base/utils/colors';
 
+.sth-form-label {
+   color: egeo-get-color(a4);
+}
+
 .sth-form-label.error {
    color: egeo-get-color(s2);
 }

--- a/src/components/_switch.scss
+++ b/src/components/_switch.scss
@@ -8,7 +8,6 @@
 .sth-switch__label {
    text-align: left;
    font-size: 15px;
-   color: egeo-get-color(n7);
 }
 
 .sth-switch__help {


### PR DESCRIPTION
Close issue #EGE-424 & #108
## TYPE
- Bugfix

## Description
Unify colors to the labels of items displayed in a form
### Documentation
- [ ] Have the sth classes documented in the website
- [ ] Have changelog.md updated

### Code
- [ ] Have 3 spaces indentation
- [ ] Pass Sass lint Task

### Other observations
- Add other information you consider important

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
