### PR TITLE
fix(st-buttons): Fix bad background color to tool buttons with theme A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.14.3 (upcoming)
+* Fix bad background color to tool buttons with theme A
+
 ## 0.14.2 (September 12, 2017)
 * Fix broken button styles
 

--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -143,7 +143,7 @@
    }
 
    &.button-rd1 {
-      background-color: egeo-get-color(n1);
+      background-color: egeo-get-color(n2);
       color: egeo-get-color(a1);
       &:not([disabled]):hover {
          background-color: egeo-get-color(a1_light);


### PR DESCRIPTION
## TYPE
- Bugfix
## Description
Fix bad background color to tool buttons with theme A

### Documentation
- [ ] Have the sth classes documented in the website
- [ ] Have changelog.md updated

### Code
- [ ] Have 3 spaces indentation
- [ ] Pass Sass lint Task

### Other observations

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
